### PR TITLE
A lot of improvements as the outcome of our face to face meeting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     </distributionManagement>
 
     <properties>
-        <jqassistant.core.version>1.3.0-SNAPSHOT</jqassistant.core.version>
-        <jqassistant.plugin.version>1.3-SNAPSHOT</jqassistant.plugin.version>
+        <jqassistant.core.version>1.3.0</jqassistant.core.version>
+        <jqassistant.plugin.version>1.3</jqassistant.plugin.version>
         <org.springframework.version>3.0.0.RELEASE</org.springframework.version>
         <org.springframework.boot_version>1.3.3.RELEASE</org.springframework.boot_version>
         <org.springframework.data_version>1.9.4.RELEASE</org.springframework.data_version>

--- a/readme.adoc
+++ b/readme.adoc
@@ -6,13 +6,28 @@ It provides pre-defined rules for projects using the http://www.spring.org/[Spri
 * Spring Boot
 ** Package layout, i.e. all classes of a Spring Boot application must be located in the package of the application
    class or a child package of it.
+** Considers classes annotated with `@SpringBootApplication` and `@TestConfiguration` configuration classes and injectables.
+   
 * Spring Components
-** Verification of dependencies between Spring components, i.e. controllers, services and repositories
+** Considers classes annotated with `@Component`, `@Service`, `@Repository` injectables.
+** Considers classes that are returned from `@Bean` methods injectables.
+** Considers Spring Data repositories injectables.
+** Verifies dependencies between Spring components, i.e. controllers (must depend on services, repositories or components), services (must depend on other services, repositories or components) and repositories (must depend on other repositories and components).
+** Requires `@Bean` methods to be used from with configuration classes only.
+ 
 * Dependency Injection
-** Prevent field injection and direct instantiation of injectable types
-** Ensure that fields of injectable stype which have been initialized by a constructor are not manipulated
+** Prevents field injection (except in tests, in Strict mode)
+** Requires injectables to be assigned to final fields (in Strict mode)
+** Rejects direct instantiation of injectable types, except in tests and `@Bean` methods.
+** Ensures that fields of injectable types are not manipulated.
+** Ensures that injectables are never assigned to static fields or accessed via static methods.
+
+** Recommends to use `@PostConstruct` and `@PreDestroy` over implementing `InitializingBean` and `DisposableBean`.
+** Recommends to directly inject `BeanFactory`, `ApplicationContext`, and `ApplicationEventPublisher` instead of implementing callback interfaces.
+ 
+
 * Transactions
-** Disallow direct invocation of transactional methods from within the same class
+** Disallow direct invocation of methods annotated with `@Transaction` from methods not annotated with that annotation within the same class
 
 For more information on jQAssistant see https://www.jqassistant.org[^].
 
@@ -27,8 +42,8 @@ For more information on jQAssistant see https://www.jqassistant.org[^].
 <project>
 
   <properties>
-    <jqassistant.version>1.1.4</jqassistant.version>
-    <jqassistant.spring.plugin.version>1.1.4-SNAPSHOT</jqassistant.spring.plugin.version>
+    <jqassistant.version>1.3</jqassistant.version>
+    <jqassistant.spring.plugin.version>1.3.0-SNAPSHOT</jqassistant.spring.plugin.version>
   </properties>
 
   <build>

--- a/src/main/resources/META-INF/jqassistant-rules/spring-boot.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-boot.xml
@@ -12,16 +12,16 @@
         <includeGroup refId="spring-component:Strict" />
         <includeGroup refId="spring-injection:Strict" />
     </group>
-    
+
     <concept id="spring-boot:Application">
-        <description>Labels all Spring Boot Applications with "Spring" and "Application".</description>
+        <description>Labels all Spring Boot Applications with "Spring", "Application", "Configuration" and "Component".</description>
         <cypher><![CDATA[
             MATCH
               (application:Type:Class)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
             WHERE
               annotationType.fqn = "org.springframework.boot.autoconfigure.SpringBootApplication"
             SET
-              application:Spring:Boot:Application
+              application:Spring:Boot:Application:Configuration:Component
             RETURN
               application as Application
         ]]></cypher>

--- a/src/main/resources/META-INF/jqassistant-rules/spring-component.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-component.xml
@@ -1,14 +1,29 @@
 <jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
 
     <group id="spring-component:Default">
-        <includeConstraint refId="spring-component:ControllerMustOnlyDependOnServicesOrRepositories"/>
-        <includeConstraint refId="spring-component:ServiceMustOnlyDependOnServicesOrRepositories"/>
-        <includeConstraint refId="spring-component:RepositoryMustOnlyDependOnRepositories"/>
+        <includeConstraint refId="spring-component:ControllerMustOnlyDependOnServicesRepositoriesOrComponents"/>
+        <includeConstraint refId="spring-component:ServiceMustOnlyDependOnServicesRepositoriesOrComponents"/>
+        <includeConstraint refId="spring-component:RepositoryMustOnlyDependOnRepositoriesOrComponents"/>
     </group>
 
     <group id="spring-component:Strict">
         <includeGroup refId="spring-component:Default"/>
     </group>
+
+    <concept id="spring-component:Component">
+        <description>Labels all types annotated with "@org.springframework.stereotype.Component" with "Spring" and "Component".
+        </description>
+        <cypher><![CDATA[
+            MATCH
+              (component:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
+            WHERE
+              annotationType.fqn = "org.springframework.stereotype.Component"
+            SET
+              component:Spring:Component:Injectable
+            RETURN
+              component as Component
+        ]]></cypher>
+    </concept>
 
     <concept id="spring-component:Controller">
         <description>Labels all types annotated with "@org.springframework.stereotype.Controller" with "Spring",
@@ -20,7 +35,7 @@
             WHERE
               annotationType.fqn = "org.springframework.stereotype.Controller"
             SET
-              controller:Spring:Controller:Component
+              controller:Spring:Controller:Injectable
             RETURN
               controller as Controller
         ]]></cypher>
@@ -36,7 +51,7 @@
             WHERE
               annotationType.fqn = "org.springframework.stereotype.Service"
             SET
-              service:Spring:Service:Component
+              service:Spring:Service:Injectable
             RETURN
               service as Service
         ]]></cypher>
@@ -48,7 +63,7 @@
         <description>Returns all repositories.</description>
         <cypher><![CDATA[
             MATCH
-              (repository:Spring:Repository:Component)
+              (repository:Spring:Repository:Injectable)
             RETURN
               repository as Repository
         ]]></cypher>
@@ -64,13 +79,14 @@
             WHERE
               annotationType.fqn = "org.springframework.context.annotation.Configuration"
             SET
-              configuration:Spring:Configuration:Component
+              configuration:Spring:Configuration:Injectable
             RETURN
               configuration as Configuration
         ]]></cypher>
     </concept>
 
-    <concept id="spring-component:Component">
+    <concept id="spring-component:AnnotatedInjectables">
+    	    <requiresConcept refId="spring-component:Component"/>
         <requiresConcept refId="spring-component:Service"/>
         <requiresConcept refId="spring-component:Controller"/>
         <requiresConcept refId="spring-component:Repository"/>
@@ -78,7 +94,7 @@
         <description>Labels all Spring Components as "Injectable".</description>
         <cypher><![CDATA[
             MATCH
-              (injectableComponent:Spring:Component)
+              (injectableComponent:Spring)
             SET
               injectableComponent:Injectable
             RETURN
@@ -87,13 +103,13 @@
     </concept>
 
     <concept id="spring-component:VirtualDependency">
-        <requiresConcept refId="spring-component:Component"/>
+        <requiresConcept refId="spring-component:AnnotatedInjectables"/>
         <description>Creates a DEPENDS_ON relation between Spring Components which are connected through interfaces or
             abstract types and adds a "virtual" property.
         </description>
         <cypher><![CDATA[
           MATCH
-             (component:Spring:Component)-[:DEPENDS_ON]->(superType)<-[:IMPLEMENTS|EXTENDS*]-(otherComponent:Spring:Component)
+             (component:Spring:Injectable)-[:DEPENDS_ON]->(superType)<-[:IMPLEMENTS|EXTENDS*]-(otherComponent:Spring:Injectable)
           WHERE
             component <> otherComponent
             and not (component)-[:EXTENDS|IMPLEMENTS*]->(superType) // exclude components sharing the same super classes/interfaces
@@ -106,34 +122,36 @@
       ]]></cypher>
     </concept>
 
-    <constraint id="spring-component:ControllerMustOnlyDependOnServicesOrRepositories">
+    <constraint id="spring-component:ControllerMustOnlyDependOnServicesRepositoriesOrComponents">
         <requiresConcept refId="spring-component:VirtualDependency"/>
         <description>A Spring controller can only have dependencies to other Spring components that are services
             or repositories.
         </description>
         <cypher><![CDATA[
             MATCH
-              (controller:Spring:Controller)-[:DEPENDS_ON]->(other:Spring:Component)
+              (controller:Spring:Controller)-[:DEPENDS_ON]->(other:Spring:Injectable)
             WHERE NOT (
               other:Service
               or other:Repository
+              or other:Component
             )
             RETURN
               controller as Controller, collect(other) as InvalidDependencies
         ]]></cypher>
     </constraint>
 
-    <constraint id="spring-component:ServiceMustOnlyDependOnServicesOrRepositories">
+    <constraint id="spring-component:ServiceMustOnlyDependOnServicesRepositoriesOrComponents">
         <requiresConcept refId="spring-component:VirtualDependency"/>
         <description>A Spring service can only have dependencies to other Spring components that are services or
             repositories.
         </description>
         <cypher><![CDATA[
             MATCH
-              (service:Spring:Service)-[:DEPENDS_ON]->(other:Spring:Component)
+              (service:Spring:Service)-[:DEPENDS_ON]->(other:Spring:Injectable)
             WHERE NOT (
               other:Service
               or other:Repository
+              or other:Component
             )
             RETURN
               service as Service, collect(other) as InvalidDependencies
@@ -141,15 +159,16 @@
     </constraint>
 
 
-    <constraint id="spring-component:RepositoryMustOnlyDependOnRepositories">
+    <constraint id="spring-component:RepositoryMustOnlyDependOnRepositoriesOrComponents">
         <requiresConcept refId="spring-component:VirtualDependency"/>
         <description>A Spring repository can only have dependencies to other Spring components that are repositories.
         </description>
         <cypher><![CDATA[
             MATCH
-              (repository:Spring:Repository)-[:DEPENDS_ON]->(other:Spring:Component)
+              (repository:Spring:Repository)-[:DEPENDS_ON]->(other:Spring:Injectable)
             WHERE NOT (
               other:Repository
+              or other:Component
             )
             RETURN
               repository as Repository, collect(other) as InvalidDependencies

--- a/src/main/resources/META-INF/jqassistant-rules/spring-component.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-component.xml
@@ -7,7 +7,6 @@
     </group>
 
     <group id="spring-component:Strict">
-        <includeConstraint refId="spring-component:ControllerMustDependEitherOnServicesOrRepositories"/>
         <includeGroup refId="spring-component:Default"/>
     </group>
 
@@ -121,26 +120,6 @@
             )
             RETURN
               controller as Controller, collect(other) as InvalidDependencies
-        ]]></cypher>
-    </constraint>
-
-    <constraint id="spring-component:ControllerMustDependEitherOnServicesOrRepositories">
-        <requiresConcept refId="spring-component:VirtualDependency"/>
-        <description>A Spring service can only have dependencies to other Spring components that are either services or
-            repositories.
-        </description>
-        <cypher><![CDATA[
-            MATCH
-              (controller:Spring:Controller)-[:DEPENDS_ON]->(other:Spring:Component)
-            WITH
-              controller, collect(other) as others
-            WHERE NOT (
-              all (other in others WHERE other:Service)
-              or
-              all (other in others WHERE other:Repository)
-            )
-            RETURN
-              controller as Controller, others as InvalidDependencies
         ]]></cypher>
     </constraint>
 

--- a/src/main/resources/META-INF/jqassistant-rules/spring-data.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-data.xml
@@ -10,7 +10,7 @@
             WHERE
               annotationType.fqn = "org.springframework.stereotype.Repository"
             SET
-              repository:Spring:Repository:Component
+              repository:Spring:Repository:Injectable
             RETURN
               repository as Repository
         ]]></cypher>
@@ -33,7 +33,7 @@
                 "org.springframework.data.jpa.repository.support.QueryDslJpaRepository"
               ]
             SET
-              repository:Spring:Repository:Component
+              repository:Spring:Repository:Injectable
             RETURN
               repository as Repository
         ]]></cypher>

--- a/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
@@ -13,6 +13,7 @@
 
     <group id="spring-injection:Strict">
         <includeConstraint refId="spring-injection:FieldInjectionIsNotAllowed"/>
+        <includeConstraint refId="spring-injection:InjectablesShouldBeHeldInFinalFields"/>
     </group>
 
     <concept id="spring-injection:Injectable">
@@ -108,6 +109,20 @@
               (exists(artifact.type) and artifact.type="test-jar")
             RETURN
               type as Type, field as Field
+        ]]></cypher>
+    </constraint>
+
+    <constraint id="spring-injection:InjectablesShouldBeHeldInFinalFields">
+        <requiresConcept refId="spring-injection:Injectable"/>
+        <requiresConcept refId="spring-injection:InjectionPoint"/>
+        <description>Fields holding injectables should be declared final.</description>
+        <cypher><![CDATA[
+            MATCH
+              (source:Type:Injectable)-[declares:DECLARES]->(field:Field)-[:OF_TYPE]->(target:Type)
+            WHERE NOT
+              exists(field.final) AND field.final = false
+            RETURN
+              source.fqn + "." + field.name + " should be declared final! Line: " + declares.lineNumber as Message
         ]]></cypher>
     </constraint>
 

--- a/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
@@ -3,7 +3,7 @@
     <group id="spring-injection:Default">
         <includeConstraint refId="spring-injection:InjectablesMustNotBeInstantiated"/>
         <includeConstraint refId="spring-injection:BeanProducerMustBeDeclaredInConfigurationComponent" />
-        <includeConstraint refId="spring-injection:FieldsInitializedByConstructorMustNotBeManipulated"/>
+        <includeConstraint refId="spring-injection:FieldsOfInjectablesMustNotBeManipulated"/>
         <includeConstraint refId="spring-injection:AvoidInitializingBean"/>
         <includeConstraint refId="spring-injection:AvoidDisposableBean"/>
         <includeConstraint refId="spring-injection:AvoidAwareInterfacesInFavorOfInjection"/>
@@ -111,19 +111,19 @@
         ]]></cypher>
     </constraint>
 
-    <constraint id="spring-injection:FieldsInitializedByConstructorMustNotBeManipulated">
+    <constraint id="spring-injection:FieldsOfInjectablesMustNotBeManipulated">
         <requiresConcept refId="spring-injection:Injectable"/>
-        <description>Fields of injectable types that are written by a constructor must not be manipulated by
-            non-constructor methods.
-        </description>
+        <description>Fields of injectable types must not be manipulated, except from constructors.</description>
         <cypher><![CDATA[
             MATCH
               (injectable:Injectable),
-              (injectable)-[:DECLARES]->(constructor:Constructor)-[:WRITES]->(field:Field),
               (injectable)-[:DECLARES]->(method:Method)-[writes:WRITES]->(field:Field)
-            WHERE NOT
-               method:Constructor
+            WHERE NOT (
+               method:Constructor OR // method is a constructor
+               (exists(field.static) AND field.static) // static fields
+            )
             RETURN
+              injectable.fqn + "." + method.name + "(…) writes field '" + field.name + "' at line " + writes.lineNumber as Message, 
               injectable as Injectable, method as Method, field as Field, writes.lineNumber as LineNumber
         ]]></cypher>
     </constraint>

--- a/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
@@ -7,6 +7,8 @@
         <includeConstraint refId="spring-injection:AvoidInitializingBean"/>
         <includeConstraint refId="spring-injection:AvoidDisposableBean"/>
         <includeConstraint refId="spring-injection:AvoidAwareInterfacesInFavorOfInjection"/>
+        <includeConstraint refId="spring-injection:InjectablesMustNotBeHeldInStaticVariables"/>
+        <includeConstraint refId="spring-injection:InjectablesMustNotBeAccessedStatically"/>
     </group>
 
     <group id="spring-injection:Strict">
@@ -167,4 +169,29 @@
         ]]></cypher>
     </constraint>
 
+    <constraint id="spring-injection:InjectablesMustNotBeHeldInStaticVariables">
+        <requiresConcept refId="spring-injection:Injectable"/>
+        <description>Injectable components must not be held in static variables.</description>
+        <cypher><![CDATA[
+            MATCH
+              (type:Type)-[:DECLARES]->(field:Field)-[:OF_TYPE]->(fieldType:Type:Injectable)
+            WHERE
+              field.static
+            RETURN
+              type as Type, field.name as Field
+        ]]></cypher>
+    </constraint>
+
+    <constraint id="spring-injection:InjectablesMustNotBeAccessedStatically">
+        <requiresConcept refId="spring-injection:Injectable"/>
+        <description>Injectable components must not be accessed from static variables.</description>
+        <cypher><![CDATA[
+            MATCH
+              (method:Method)-[:READS]->(field:Field)-[:OF_TYPE]->(fieldType:Type:Injectable)
+            WHERE
+              field.static
+            RETURN
+              method as Method, field.name as Field
+        ]]></cypher>
+    </constraint>
 </jqa:jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-injection.xml
@@ -14,7 +14,7 @@
     </group>
 
     <concept id="spring-injection:Injectable">
-        <requiresConcept refId="spring-component:Component"/>
+        <requiresConcept refId="spring-component:AnnotatedInjectables"/>
         <requiresConcept refId="spring-injection:BeanProducer"/>
         <description>Returns all injectables.</description>
         <cypher><![CDATA[
@@ -69,7 +69,7 @@
             MATCH
               (type:Type)-[:DECLARES]->(beanProducer:Method:BeanProducer)-[:RETURNS]->(injectable:Injectable)
             WHERE NOT
-              type:Spring:Component:Configuration
+              type:Spring:Configuration
             RETURN
               beanProducer as BeanProducer, injectable as Injectable
         ]]></cypher>

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/concept/ComponentIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/concept/ComponentIT.java
@@ -27,7 +27,7 @@ public class ComponentIT extends AbstractSpringIT {
         scanClasses(ConfigurationWithBeanProducer.class);
         assertThat(applyConcept("spring-component:Configuration").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
-        List<Object> configurations = query("MATCH (c:Spring:Configuration:Component) RETURN c").getColumn("c");
+        List<Object> configurations = query("MATCH (c:Spring:Configuration) RETURN c").getColumn("c");
         assertThat(configurations, hasItem(typeDescriptor(ConfigurationWithBeanProducer.class)));
         store.commitTransaction();
     }
@@ -40,7 +40,7 @@ public class ComponentIT extends AbstractSpringIT {
         scanClasses(Controller.class);
         assertThat(applyConcept("spring-component:Controller").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
-        assertThat(query("MATCH (c:Spring:Controller:Component) RETURN c").getColumn("c"), hasItem(typeDescriptor(Controller.class)));
+        assertThat(query("MATCH (c:Spring:Controller) RETURN c").getColumn("c"), hasItem(typeDescriptor(Controller.class)));
         store.commitTransaction();
     }
 
@@ -53,7 +53,7 @@ public class ComponentIT extends AbstractSpringIT {
         assertThat(applyConcept("spring-component:Service").getStatus(), equalTo(SUCCESS));
 
         store.beginTransaction();
-        assertThat(query("MATCH (s:Spring:Service:Component) RETURN s").getColumn("s"), hasItem(typeDescriptor(Service.class)));
+        assertThat(query("MATCH (s:Spring:Service) RETURN s").getColumn("s"), hasItem(typeDescriptor(Service.class)));
         store.commitTransaction();
     }
 
@@ -62,7 +62,7 @@ public class ComponentIT extends AbstractSpringIT {
         scanClasses(AnnotatedRepository.class, ImplementedRepository.class);
         assertThat(applyConcept("spring-component:Repository").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
-        List<Object> repositories = query("MATCH (r:Spring:Repository:Component) RETURN r").getColumn("r");
+        List<Object> repositories = query("MATCH (r:Spring:Repository) RETURN r").getColumn("r");
         assertThat(repositories, hasItem(typeDescriptor(AnnotatedRepository.class)));
         assertThat(repositories, hasItem(typeDescriptor(ImplementedRepository.class)));
         store.commitTransaction();
@@ -75,8 +75,8 @@ public class ComponentIT extends AbstractSpringIT {
         assertThat(applyConcept("spring-component:Controller").getStatus(), equalTo(SUCCESS));
         assertThat(applyConcept("spring-component:Service").getStatus(), equalTo(SUCCESS));
         assertThat(applyConcept("spring-component:Repository").getStatus(), equalTo(SUCCESS));
-        verifyComponentDependencies("MATCH (:Spring:Controller)-[:DEPENDS_ON]->(c:Spring:Component) RETURN c", TestService1.class);
-        verifyComponentDependencies("MATCH (:Spring:Service)-[:DEPENDS_ON]->(c:Spring:Component) RETURN c", TestRepository1.class);
+        verifyComponentDependencies("MATCH (:Spring:Controller)-[:DEPENDS_ON]->(c:Spring:Injectable) RETURN c", TestService1.class);
+        verifyComponentDependencies("MATCH (:Spring:Service)-[:DEPENDS_ON]->(c:Spring:Injectable) RETURN c", TestRepository1.class);
     }
 
     @Test
@@ -84,11 +84,11 @@ public class ComponentIT extends AbstractSpringIT {
         scanClasses(TestController.class, AbstractTestController.class, TestController1.class, TestController2.class, TestService.class, TestServiceImpl.class,
                 TestRepository.class, TestRepositoryImpl.class);
         assertThat(applyConcept("spring-component:VirtualDependency").getStatus(), equalTo(SUCCESS));
-        verifyComponentDependencies("MATCH (:Spring:Controller{name:'TestController1'})-[:DEPENDS_ON{virtual:true}]->(c:Spring:Component) RETURN c",
+        verifyComponentDependencies("MATCH (:Spring:Controller{name:'TestController1'})-[:DEPENDS_ON{virtual:true}]->(c:Spring:Injectable) RETURN c",
                 TestServiceImpl.class);
-        verifyComponentDependencies("MATCH (:Spring:Controller{name:'TestController2'})-[:DEPENDS_ON{virtual:true}]->(c:Spring:Component) RETURN c",
+        verifyComponentDependencies("MATCH (:Spring:Controller{name:'TestController2'})-[:DEPENDS_ON{virtual:true}]->(c:Spring:Injectable) RETURN c",
                 TestServiceImpl.class);
-        verifyComponentDependencies("MATCH (:Spring:Service)-[:DEPENDS_ON{virtual:true}]->(c:Spring:Component) RETURN c", TestRepositoryImpl.class);
+        verifyComponentDependencies("MATCH (:Spring:Service)-[:DEPENDS_ON{virtual:true}]->(c:Spring:Injectable) RETURN c", TestRepositoryImpl.class);
     }
 
     private void verifyComponentDependencies(String query, Class<?>... dependencies) {

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/concept/RepositoryIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/concept/RepositoryIT.java
@@ -23,7 +23,7 @@ public class RepositoryIT extends AbstractSpringIT {
         assertThat(applyConcept("spring-data:AnnotatedRepository").getStatus(), equalTo(SUCCESS));
        
         store.beginTransaction();
-        assertThat(query("MATCH (r:Spring:Repository:Component) RETURN r").getColumn("r"), hasItem(typeDescriptor(AnnotatedRepository.class)));
+        assertThat(query("MATCH (r:Spring:Repository) RETURN r").getColumn("r"), hasItem(typeDescriptor(AnnotatedRepository.class)));
         store.commitTransaction();
     }
 
@@ -35,7 +35,7 @@ public class RepositoryIT extends AbstractSpringIT {
         scanClasses(ImplementedRepository.class);
         assertThat(applyConcept("spring-data:ImplementedRepository").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
-        assertThat(query("MATCH (r:Spring:Repository:Component) RETURN r").getColumn("r"), hasItem(typeDescriptor(ImplementedRepository.class)));
+        assertThat(query("MATCH (r:Spring:Repository) RETURN r").getColumn("r"), hasItem(typeDescriptor(ImplementedRepository.class)));
         store.commitTransaction();
     }
 }

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/DependencyStructureIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/DependencyStructureIT.java
@@ -23,61 +23,59 @@ import com.buschmais.jqassistant.plugin.spring.test.set.components.dependencies.
 
 public class DependencyStructureIT extends AbstractJavaPluginIT {
 
-    @Test
+    private static final String CONSTRAINT_ALLOWED_CONTROLLER_DEPENDENCIES = "spring-component:ControllerMustOnlyDependOnServicesRepositoriesOrComponents";
+    	private static final String CONSTRAINT_ALLOWED_SERVICE_DEPENDENCIES = "spring-component:ServiceMustOnlyDependOnServicesRepositoriesOrComponents";
+    	private static final String CONSTRAINT_ALLOWED_REPOSITORY_DEPENDENCIES = "spring-component:RepositoryMustOnlyDependOnRepositoriesOrComponents";
+   
+
+		@Test
     public void controllerDependsOnService() throws Exception {
         scanClasses(TestController1.class, TestService1.class);
-        assertThat(validateConstraint("spring-component:ControllerMustOnlyDependOnServicesOrRepositories").getStatus(), equalTo(SUCCESS));
+        assertThat(validateConstraint(CONSTRAINT_ALLOWED_CONTROLLER_DEPENDENCIES).getStatus(), equalTo(SUCCESS));
     }
 
     @Test
     public void controllerDependsRepository() throws Exception {
         scanClasses(TestControllerWithRepositoryDependency.class, TestRepository1.class);
-        assertThat(validateConstraint("spring-component:ControllerMustOnlyDependOnServicesOrRepositories").getStatus(), equalTo(SUCCESS));
+        assertThat(validateConstraint(CONSTRAINT_ALLOWED_CONTROLLER_DEPENDENCIES).getStatus(), equalTo(SUCCESS));
     }
 
     @Test
     public void controllerDependsOnController() throws Exception {
         scanClasses(TestControllerWithControllerDependency.class, TestController1.class);
-        verifyConstraintViolation("spring-component:ControllerMustOnlyDependOnServicesOrRepositories", "Controller", TestControllerWithControllerDependency.class,
+        verifyConstraintViolation(CONSTRAINT_ALLOWED_CONTROLLER_DEPENDENCIES, "Controller", TestControllerWithControllerDependency.class,
                 TestController1.class);
     }
 
     @Test
     public void controllerDependsOnServiceAndRepository() throws Exception {
         scanClasses(TestControllerWithServiceAndRepositoryDependency.class, TestService1.class, TestRepository1.class);
-        assertThat(validateConstraint("spring-component:ControllerMustOnlyDependOnServicesOrRepositories").getStatus(), equalTo(SUCCESS));
-    }
-
-    @Test
-    public void controllerDependsEitherOnServiceOrRepository() throws Exception {
-        scanClasses(TestControllerWithServiceAndRepositoryDependency.class, TestService1.class, TestRepository1.class);
-        verifyConstraintViolation("spring-component:ControllerMustDependEitherOnServicesOrRepositories", "Controller",
-                TestControllerWithServiceAndRepositoryDependency.class, TestService1.class, TestRepository1.class);
+        assertThat(validateConstraint(CONSTRAINT_ALLOWED_CONTROLLER_DEPENDENCIES).getStatus(), equalTo(SUCCESS));
     }
 
     @Test
     public void serviceDependsOnServiceAndRepository() throws Exception {
         scanClasses(TestController1.class, TestService1.class, TestService2.class, TestRepository1.class);
-        assertThat(validateConstraint("spring-component:ServiceMustOnlyDependOnServicesOrRepositories").getStatus(), equalTo(SUCCESS));
+        assertThat(validateConstraint(CONSTRAINT_ALLOWED_SERVICE_DEPENDENCIES).getStatus(), equalTo(SUCCESS));
     }
 
     @Test
     public void repositoryDependsOnRepository() throws Exception {
         scanClasses(TestRepository1.class, TestRepository2.class);
-        assertThat(validateConstraint("spring-component:RepositoryMustOnlyDependOnRepositories").getStatus(), equalTo(SUCCESS));
+        assertThat(validateConstraint(CONSTRAINT_ALLOWED_REPOSITORY_DEPENDENCIES).getStatus(), equalTo(SUCCESS));
     }
 
     @Test
     public void repositoryDependsOnController() throws Exception {
         scanClasses(TestRepositoryWithControllerDependency.class, TestController1.class);
-        verifyConstraintViolation("spring-component:RepositoryMustOnlyDependOnRepositories", "Repository", TestRepositoryWithControllerDependency.class,
+        verifyConstraintViolation(CONSTRAINT_ALLOWED_REPOSITORY_DEPENDENCIES, "Repository", TestRepositoryWithControllerDependency.class,
                 TestController1.class);
     }
 
     @Test
     public void repositoryDependsOnService() throws Exception {
         scanClasses(TestRepositoryWithServiceDependency.class, TestService1.class);
-        verifyConstraintViolation("spring-component:RepositoryMustOnlyDependOnRepositories", "Repository", TestRepositoryWithServiceDependency.class,
+        verifyConstraintViolation(CONSTRAINT_ALLOWED_REPOSITORY_DEPENDENCIES, "Repository", TestRepositoryWithServiceDependency.class,
                 TestService1.class);
     }
 

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/FieldsOfInjectablesMustNotBeManipulatedIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/FieldsOfInjectablesMustNotBeManipulatedIT.java
@@ -7,14 +7,12 @@ import static com.buschmais.jqassistant.plugin.java.test.matcher.MethodDescripto
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
 
 import com.buschmais.jqassistant.core.analysis.api.Result;
-import com.buschmais.jqassistant.core.analysis.api.Result.Status;
 import com.buschmais.jqassistant.core.analysis.api.rule.Constraint;
 import com.buschmais.jqassistant.plugin.java.api.model.MethodDescriptor;
 import com.buschmais.jqassistant.plugin.java.test.AbstractJavaPluginIT;
@@ -31,11 +29,11 @@ public class FieldsOfInjectablesMustNotBeManipulatedIT extends AbstractJavaPlugi
         assertThat(result.getStatus(), equalTo(FAILURE));
 
         store.beginTransaction();
-        
-        String message = result.getRows().get(0).get("Result").toString();
-        
+
+        String message = result.getRows().get(0).get("Message").toString();
+
         assertThat(message, containsString(ServiceWritingConstructorField.class.getName()));
-        assertThat(message, containsString("value"));
+        assertThat(message, containsString("'value'"));
 
         assertThat(result, result(constraint("spring-injection:FieldsOfInjectablesMustNotBeManipulated")));
         List<Map<String, Object>> rows = result.getRows();

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/FieldsOfInjectablesMustNotBeManipulatedIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/FieldsOfInjectablesMustNotBeManipulatedIT.java
@@ -4,7 +4,7 @@ import static com.buschmais.jqassistant.core.analysis.api.Result.Status.FAILURE;
 import static com.buschmais.jqassistant.core.analysis.test.matcher.ConstraintMatcher.constraint;
 import static com.buschmais.jqassistant.core.analysis.test.matcher.ResultMatcher.result;
 import static com.buschmais.jqassistant.plugin.java.test.matcher.MethodDescriptorMatcher.methodDescriptor;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
@@ -14,26 +14,35 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.buschmais.jqassistant.core.analysis.api.Result;
+import com.buschmais.jqassistant.core.analysis.api.Result.Status;
 import com.buschmais.jqassistant.core.analysis.api.rule.Constraint;
 import com.buschmais.jqassistant.plugin.java.api.model.MethodDescriptor;
 import com.buschmais.jqassistant.plugin.java.test.AbstractJavaPluginIT;
 import com.buschmais.jqassistant.plugin.spring.test.set.constructors.ServiceWritingConstructorField;
 
-public class ConstructorFieldsMustNotBeManipulatedIT extends AbstractJavaPluginIT {
+public class FieldsOfInjectablesMustNotBeManipulatedIT extends AbstractJavaPluginIT {
 
     @Test
     public void constructorFieldsMustNotBeManipulated() throws Exception {
-        scanClasses(ServiceWritingConstructorField.class);
-        assertThat(validateConstraint("spring-injection:FieldsInitializedByConstructorMustNotBeManipulated").getStatus(), equalTo(FAILURE));
+
+    	    scanClasses(ServiceWritingConstructorField.class);
+
+        Result<Constraint> result = validateConstraint("spring-injection:FieldsOfInjectablesMustNotBeManipulated");
+        assertThat(result.getStatus(), equalTo(FAILURE));
+
         store.beginTransaction();
-        List<Result<Constraint>> constraintViolations = new ArrayList<>(reportWriter.getConstraintResults().values());
-        assertThat(constraintViolations.size(), equalTo(1));
-        Result<Constraint> result = constraintViolations.get(0);
-        assertThat(result, result(constraint("spring-injection:FieldsInitializedByConstructorMustNotBeManipulated")));
+        
+        String message = result.getRows().get(0).get("Result").toString();
+        
+        assertThat(message, containsString(ServiceWritingConstructorField.class.getName()));
+        assertThat(message, containsString("value"));
+
+        assertThat(result, result(constraint("spring-injection:FieldsOfInjectablesMustNotBeManipulated")));
         List<Map<String, Object>> rows = result.getRows();
         assertThat(rows.size(), equalTo(1));
         MethodDescriptor method = (MethodDescriptor) rows.get(0).get("Method");
         assertThat(method, methodDescriptor(ServiceWritingConstructorField.class, "setValue", String.class));
+
         store.commitTransaction();
     }
 

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/InjectablesMustNotBeReferredToStaticallyIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/constraint/InjectablesMustNotBeReferredToStaticallyIT.java
@@ -1,0 +1,81 @@
+package com.buschmais.jqassistant.plugin.spring.test.constraint;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.stereotype.Component;
+
+import com.buschmais.jqassistant.core.analysis.api.Result;
+import com.buschmais.jqassistant.core.analysis.api.Result.Status;
+import com.buschmais.jqassistant.core.analysis.api.rule.Constraint;
+import com.buschmais.jqassistant.plugin.java.api.model.MethodDescriptor;
+import com.buschmais.jqassistant.plugin.java.api.model.TypeDescriptor;
+import com.buschmais.jqassistant.plugin.java.test.AbstractJavaPluginIT;
+import com.buschmais.jqassistant.plugin.java.test.matcher.MethodDescriptorMatcher;
+import com.buschmais.jqassistant.plugin.java.test.matcher.TypeDescriptorMatcher;
+
+/**
+ * Integration tests for rules rejecting static references to injectables.
+ *
+ * @author Oliver Gierke
+ */
+public class InjectablesMustNotBeReferredToStaticallyIT extends AbstractJavaPluginIT {
+
+	@Test
+	public void reportsInjectablesInStaticFields() throws Exception {
+		
+		scanClasses(MyComponent.class, MyDependency.class);
+		
+		Result<Constraint> result = validateConstraint("spring-injection:InjectablesMustNotBeHeldInStaticVariables");
+		
+		store.beginTransaction();
+		
+		assertThat(result.getStatus(), is(Status.FAILURE));
+		assertThat(result.getRows(), hasSize(1));
+		
+		Map<String, Object> map = result.getRows().get(0);
+		TypeDescriptor descriptor = (TypeDescriptor) map.get("Type");
+		
+		assertThat(descriptor, TypeDescriptorMatcher.typeDescriptor(MyComponent.class));
+		assertThat(map.get("Field"), is((Object) "dependency"));
+		
+		store.rollbackTransaction();
+	}
+
+	@Test
+	public void reportsStaticReferenceToInjectable() throws Exception {
+		
+		scanClasses(MyComponent.class, MyDependency.class);
+		
+		Result<Constraint> result = validateConstraint("spring-injection:InjectablesMustNotBeAccessedStatically");
+		
+		store.beginTransaction();
+		
+		assertThat(result.getStatus(), is(Status.FAILURE));
+		assertThat(result.getRows(), hasSize(1));
+		
+		Map<String, Object> map = result.getRows().get(0);
+		MethodDescriptor descriptor = (MethodDescriptor) map.get("Method");
+		
+		assertThat(descriptor, MethodDescriptorMatcher.methodDescriptor(MyDependency.class, "someMethod"));
+		assertThat(map.get("Field"), is((Object) "dependency"));
+		
+		store.rollbackTransaction();
+	}
+	
+	@Component
+	static class MyComponent {
+		static MyDependency dependency;
+	}
+	
+	@Component
+	static class MyDependency {
+		
+		public static MyDependency someMethod() {
+			return MyComponent.dependency;
+		}
+	}
+}

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/set/constructors/ServiceWritingConstructorField.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/set/constructors/ServiceWritingConstructorField.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class ServiceWritingConstructorField {
 
+    // Static fields are okay
+    static final String CONSTANT = "CONSTANT";
+
     private String value;
 
     @Autowired


### PR DESCRIPTION
See the individual commit messages for details. The latest change 9e9de8a summarizes the new state of rules in the updated README.

`reportsStaticReferenceToInjectable()` in 94c530b fails for some reason but couldn't wrap my head around how to use the test API properly. Probably worth checking.