### PR TITLE
Updated version and group id

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -42,15 +42,15 @@ For more information on jQAssistant see https://www.jqassistant.org[^].
 <project>
 
   <properties>
-    <jqassistant.version>1.4.0-SNAPSHOT</jqassistant.version>
-    <jqassistant.spring.plugin.version>1.4-SNAPSHOT</jqassistant.spring.plugin.version>
+    <jqassistant.version>1.4.0</jqassistant.version>
+    <jqassistant.spring.plugin.version>1.4</jqassistant.spring.plugin.version>
   </properties>
 
   <build>
     <plugins>
       <plugin>
         <!-- <1> -->
-        <groupId>com.buschmais.jqassistant.scm</groupId>
+        <groupId>com.buschmais.jqassistant</groupId>
         <artifactId>jqassistant-maven-plugin</artifactId>
         <version>${jqassistant.version}</version>
 


### PR DESCRIPTION
I was playing with the example and discovered that the group id has changed and version 1.4(.0) is meanwhile released.  