### PR TITLE
Exclude Annotation types from being labelled with Spring component labels.

### DIFF
--- a/src/main/resources/META-INF/jqassistant-rules/spring-component.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-component.xml
@@ -20,7 +20,8 @@
             MATCH
               (component:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
             WHERE
-              annotationType.fqn in [
+              NOT component:Annotation
+              AND annotationType.fqn in [
                 "org.springframework.stereotype.Component",
                 "org.springframework.web.bind.annotation.ControllerAdvice"
               ]
@@ -41,7 +42,8 @@
             MATCH
               (controller:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
             WHERE
-              annotationType.fqn in [
+              NOT controller:Annotation
+              AND annotationType.fqn in [
                 "org.springframework.stereotype.Controller"
               ]
             SET
@@ -61,7 +63,8 @@
             MATCH
               (service:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
             WHERE
-              annotationType.fqn in [
+              NOT service:Annotation
+              AND annotationType.fqn in [
                 "org.springframework.stereotype.Service"
               ]
             SET
@@ -93,7 +96,8 @@
             MATCH
               (configuration:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
             WHERE
-              annotationType.fqn in [
+              NOT configuration:Annotation
+              AND annotationType.fqn in [
                 "org.springframework.context.annotation.Configuration",
                 "org.springframework.boot.autoconfigure.SpringBootApplication",
                 "org.springframework.data.web.config.SpringDataWebConfigurationMixin"

--- a/src/main/resources/META-INF/jqassistant-rules/spring-data.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-data.xml
@@ -13,7 +13,8 @@
             MATCH
               (repository:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
             WHERE
-              annotationType.fqn = "org.springframework.stereotype.Repository"
+              NOT repository:Annotation
+              AND annotationType.fqn = "org.springframework.stereotype.Repository"
             SET
               repository:Spring:Repository:Component:Injectable
             RETURN

--- a/src/main/resources/META-INF/jqassistant-rules/spring-mvc.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring-mvc.xml
@@ -14,7 +14,8 @@
             MATCH
               (restController:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(annotationType:Type)
             WHERE
-              annotationType.fqn = "org.springframework.web.bind.annotation.RestController"
+              NOT restController:Annotation
+              AND annotationType.fqn = "org.springframework.web.bind.annotation.RestController"
             SET
               restController:Spring:RestController:Controller:Component:Injectable
             RETURN

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/concept/InjectableIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/concept/InjectableIT.java
@@ -17,6 +17,7 @@ import static com.buschmais.jqassistant.plugin.java.test.matcher.MethodDescripto
 import static com.buschmais.jqassistant.plugin.java.test.matcher.TypeDescriptorMatcher.typeDescriptor;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class InjectableIT extends AbstractSpringIT {
@@ -55,7 +56,7 @@ class InjectableIT extends AbstractSpringIT {
     @Test
     void injectable() throws Exception {
         scanClasses(Application.class, ConfigurationWithBeanProducer.class, AnnotatedRepository.class, ImplementedRepository.class, Controller.class,
-                RestController.class, Service.class);
+                RestController.class, Service.class, AnnotatedAnnotation.class);
         assertThat(applyConcept("spring-injection:Injectable").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         List<Object> injectables = query("MATCH (i:Type:Spring:Injectable) RETURN i").getColumn("i");
@@ -68,6 +69,7 @@ class InjectableIT extends AbstractSpringIT {
         assertThat(injectables, hasItem(typeDescriptor(Controller.class)));
         assertThat(injectables, hasItem(typeDescriptor(RestController.class)));
         assertThat(injectables, hasItem(typeDescriptor(Service.class)));
+        assertThat(injectables, not(hasItem(typeDescriptor(AnnotatedAnnotation.class))));
         store.commitTransaction();
     }
 

--- a/src/test/java/com/buschmais/jqassistant/plugin/spring/test/set/components/AnnotatedAnnotation.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/spring/test/set/components/AnnotatedAnnotation.java
@@ -1,0 +1,8 @@
+package com.buschmais.jqassistant.plugin.spring.test.set.components;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public @interface AnnotatedAnnotation {
+
+}


### PR DESCRIPTION
Exclude Annotation types from being labelled with Spring Controller/Service/Component/RestController/Repository labels.

Fixes #44.